### PR TITLE
Complete hw5

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -66,6 +66,23 @@
 
   <dependencies>
 
+    <!-- Mockito Core (for unit tests) -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.7.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Mockito JUnit 5 Extension (if using JUnit 5) -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.7.0</version>
+      <scope>test</scope>
+    </dependency>
+
+
     <!-- START COMPILE DEPENDENCIES !-->
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/h2/src/main/org/h2/command/query/Optimizer.java
+++ b/h2/src/main/org/h2/command/query/Optimizer.java
@@ -82,7 +82,9 @@ class Optimizer {
         } else {
             startNs = System.nanoTime();
             if (filters.length <= MAX_BRUTE_FORCE_FILTERS) {
-                calculateBruteForceAll(isSelectCommand);
+                RuleBasedJoinOrderPicker ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(session, filters);
+                TableFilter[] ruleBasedResult = ruleBasedJoinOrderPicker.bestOrder();
+                testPlan(ruleBasedResult, isSelectCommand);
             } else {
                 calculateBruteForceSome(isSelectCommand);
                 random = new Random(0);

--- a/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
+++ b/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
@@ -1,0 +1,73 @@
+package org.h2.command.query;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.h2.engine.SessionLocal;
+import org.h2.expression.Expression;
+import org.h2.table.TableFilter;
+
+/**
+ * Determines the best join order by following rules rather than considering every possible permutation.
+ */
+public class RuleBasedJoinOrderPicker {
+    final SessionLocal session;
+    final TableFilter[] filters;
+
+    public RuleBasedJoinOrderPicker(SessionLocal session, TableFilter[] filters) {
+        this.session = session;
+        this.filters = filters;
+    }
+
+    public TableFilter[] bestOrder() {
+        Arrays.sort(filters, Comparator.comparingLong(o -> o.getTable().getRowCountApproximation(session)));
+
+        String sql_expression = filters[0].getFullCondition().getSQL(0, Expression.AUTO_PARENTHESES);
+        String[] join_expression_lines = Arrays.stream(sql_expression.split("\n"))
+                .filter(str -> (str.chars().filter(c -> c == '\"').count() == 8))
+                .toArray(String[]::new);
+
+        for (int i = 0; i < join_expression_lines.length; ++i) {
+            System.out.println(join_expression_lines[i]);
+        }
+
+        Map<String, Set<String>> alias_map = new HashMap<>();
+        for (int i = 0; i < join_expression_lines.length; ++i) {
+            String line = join_expression_lines[i];
+            int alias_1_start_idx = line.indexOf("\"");
+            int alias_1_end_idx = line.indexOf("\"", alias_1_start_idx + 1);
+            int alias_2_start_idx = line.indexOf("\"", line.indexOf("="));
+            int alias_2_end_idx = line.indexOf("\"", alias_2_start_idx + 1);
+
+            String alias_1 = line.substring(alias_1_start_idx + 1, alias_1_end_idx);
+            String alias_2 = line.substring(alias_2_start_idx + 1, alias_2_end_idx);
+
+            alias_map.computeIfAbsent(alias_1, k -> new HashSet<>()).add(alias_2);
+            alias_map.computeIfAbsent(alias_2, k -> new HashSet<>()).add(alias_1);
+        }
+
+        for (int i = 0; i < filters.length - 2; ++i) {
+            for (int j = i + 1; j < filters.length; ++j) {
+                String alias_1 = filters[i].getTable().getName();
+                alias_1 = alias_1.substring(alias_1.indexOf(".") + 1);
+
+                String alias_2 = filters[j].getTable().getName();
+                alias_2 = alias_2.substring(alias_2.indexOf(".") + 1);
+
+                if (alias_map.get(alias_1).contains(alias_2)) {
+                    TableFilter temp = filters[j];
+                    for (int k = j; k > i + 1; --k) {
+                        filters[k] = filters[k - 1];
+                    }
+                    filters[i + 1] = temp;
+                    break;
+                }
+            }
+        }
+
+        return filters;
+    }
+}

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -1292,4 +1292,8 @@ public class TableFilter implements ColumnResolver {
         }
     }
 
+    public Expression getFullCondition() {
+        return fullCondition;
+    }
+
 }

--- a/h2/src/test/org/h2/command/query/RuleBasedJoinOrderPickerTest.java
+++ b/h2/src/test/org/h2/command/query/RuleBasedJoinOrderPickerTest.java
@@ -1,0 +1,215 @@
+package org.h2.command.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.h2.engine.Database;
+import org.h2.engine.SessionLocal;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionColumn;
+import org.h2.expression.condition.BooleanTest;
+import org.h2.expression.condition.Comparison;
+import org.h2.expression.condition.ConditionAndOr;
+import org.h2.expression.condition.ConditionAndOrN;
+import org.h2.table.Table;
+import org.h2.table.TableFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RuleBasedJoinOrderPickerTest {
+    SessionLocal mockSession;
+    Database mockDatabase;
+
+    RuleBasedJoinOrderPicker ruleBasedJoinOrderPicker;
+
+    Table customersTable;
+    Table locationsTable;
+    Table ordersTable;
+    Table orderLinesTable;
+
+    ExpressionColumn locationsLocationId;
+
+    ExpressionColumn customersCustomerId;
+    ExpressionColumn customersLocationId;
+
+    ExpressionColumn ordersOrderId;
+    ExpressionColumn ordersLocationId;
+    ExpressionColumn ordersCustomerId;
+
+    ExpressionColumn orderLinesOrderLineId;
+    ExpressionColumn orderLinesOrderId;
+    ExpressionColumn orderLinesLocationId;
+    ExpressionColumn orderLinesCustomerId;
+
+    @BeforeEach
+    public void setUp(){
+        mockSession = Mockito.mock(SessionLocal.class);
+        Mockito.when(mockSession.nextObjectId()).thenReturn(1);
+
+        mockDatabase = Mockito.mock(Database.class);
+
+        // for the purposes of this unit test, we will use four mock tables with
+        // multiple relationships between them
+        locationsTable = Mockito.mock(Table.class);
+        Mockito.when(locationsTable.getName()).thenReturn("locations");
+        Mockito.when(locationsTable.getRowCountApproximation(mockSession)).thenReturn(15L);
+
+        customersTable = Mockito.mock(Table.class);
+        Mockito.when(customersTable.getName()).thenReturn("customers");
+        Mockito.when(customersTable.getRowCountApproximation(mockSession)).thenReturn(50L);
+
+        ordersTable = Mockito.mock(Table.class);
+        Mockito.when(ordersTable.getName()).thenReturn("orders");
+        Mockito.when(ordersTable.getRowCountApproximation(mockSession)).thenReturn(1000L);
+
+        orderLinesTable = Mockito.mock(Table.class);
+        Mockito.when(orderLinesTable.getName()).thenReturn("orderLines");
+        Mockito.when(orderLinesTable.getRowCountApproximation(mockSession)).thenReturn(5000L);
+
+        // locations (15 rows)
+        //  -> location_id
+        locationsLocationId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(locationsLocationId.getTableName()).thenReturn("locations");
+        // customers (50 rows)
+        //  -> location_id
+        customersCustomerId = Mockito.mock(ExpressionColumn.class);
+        customersLocationId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(customersCustomerId.getTableName()).thenReturn("customers");
+        Mockito.when(customersLocationId.getTableName()).thenReturn("customers");
+        // orders (1,000 rows)
+        //  -> location_id
+        //  -> customer_id
+        ordersOrderId = Mockito.mock(ExpressionColumn.class);
+        ordersLocationId = Mockito.mock(ExpressionColumn.class);
+        ordersCustomerId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(ordersOrderId.getTableName()).thenReturn("orders");
+        Mockito.when(ordersLocationId.getTableName()).thenReturn("orders");
+        Mockito.when(ordersCustomerId.getTableName()).thenReturn("orders");
+        // order_lines (5,000)
+        //  -> order_id
+        //  -> location_id
+        //  -> customer_id
+        orderLinesOrderLineId = Mockito.mock(ExpressionColumn.class);
+        orderLinesOrderId = Mockito.mock(ExpressionColumn.class);
+        orderLinesLocationId = Mockito.mock(ExpressionColumn.class);
+        orderLinesCustomerId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(orderLinesOrderLineId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesOrderId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesLocationId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesCustomerId.getTableName()).thenReturn("orderLines");
+    }
+
+    @Test
+    public void bestOrder_singleTable(){
+        TableFilter tableFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        tableFilter.setFullCondition(null);
+
+        List<TableFilter> expectedFilters = List.of(tableFilter);
+        TableFilter[] inputFilters = {tableFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_twoTablesSingleJoin(){
+        Expression locationsAndCustomers = new Comparison(
+                Comparison.EQUAL,
+                locationsLocationId,
+                customersLocationId,
+                false);
+
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        locationsAndCustomers
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        // locations is smaller so should go first
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter);
+
+        TableFilter[] inputFilters = {customersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_threeTablesMultipleJoins(){
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
+                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
+                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false)
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        TableFilter ordersFilter = new TableFilter(mockSession, ordersTable, "orders", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        // size order is locations, customers, orders
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter, ordersFilter);
+
+        TableFilter[] inputFilters = {customersFilter, ordersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_fourTablesMultipleJoins(){
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
+                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
+                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesLocationId, locationsLocationId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesOrderId, ordersOrderId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesCustomerId, customersCustomerId, false)
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        TableFilter ordersFilter = new TableFilter(mockSession, ordersTable, "orders", true, null, 0, null);
+        ordersFilter.setFullCondition(fullCondition);
+
+        TableFilter orderLinesFilter = new TableFilter(mockSession, orderLinesTable, "orderLines", true, null, 0, null);
+        orderLinesFilter.setFullCondition(fullCondition);
+
+        // size order is locations, customers, orders, orderLines
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter, ordersFilter, orderLinesFilter);
+
+        TableFilter[] inputFilters = {orderLinesFilter, customersFilter, ordersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+}


### PR DESCRIPTION
## Query from HW 4 Problem 4 
 
![Screenshot 2025-03-28 at 2 32 24 PM](https://github.com/user-attachments/assets/df515e16-8042-41e3-84f4-01ca9987dd12)

I am satisfied with the above plan because first it uses the table with the least amount of rows (users), then it searches for the next table with the least amount of rows that is explicitly joined onto users (followers), then it joins the last row (posts).
 
## HW 5 : Query 1 - Single Table
 
![Screenshot 2025-03-28 at 2 57 28 PM](https://github.com/user-attachments/assets/5362b941-8845-4e15-a7b9-a541dbba5855)
 
I am satisfied because this should be normal behavior regardless if I made any changes to the order.
 
## HW 5 : Query 2 - Just Two Tables
 
![Screenshot 2025-03-28 at 3 00 47 PM](https://github.com/user-attachments/assets/0d753eec-0b29-4f3d-8c26-9652a5f0ebe0)
 
I am satisfied because this should be normal behavior regardless if I made any changes to the order. And changing the order will not matter in terms of performance.
 
## HW 5 : Query 3 - Three Tables
 
![Screenshot 2025-03-28 at 3 01 18 PM](https://github.com/user-attachments/assets/6957d544-f508-4a6a-86a6-9c2178fb1aa0)
 
I am satisfied because it chooses products first as the table with the least rows, then it selects order_details to prevent cartesian product, then it selects orders last.
 
## HW 5 : Query 4 - Four Tables
 
![Screenshot 2025-03-28 at 3 03 44 PM](https://github.com/user-attachments/assets/74d8a5ea-704b-481f-8b72-23164f765f81)

I am satisfied because it chooses customers as the table with the least rows first, then it selects orders because it's joining on customers, then it selects order_details because it's joining on orders, then it selects products last.
 
## HW 5 : Query 5 - Five Tables
 
![Screenshot 2025-03-28 at 3 06 13 PM](https://github.com/user-attachments/assets/62396b9a-e30c-4db0-9aa2-12a67e777b95)

I am satisfied because it does the exact same thing in query 4, but it adds a join from suppliers on products.
 
## HW 5 : Query 6 - Four Tables, More Options
 
![Screenshot 2025-03-28 at 3 07 59 PM](https://github.com/user-attachments/assets/0aee0c9f-a5f6-4fd5-bd8e-509383f4cc9b)
 
I am satisfied because it first chooses products because the table has the least amount of rows, then it joins order_details on products, then it chooses to join order_payments instead of orders on order_details because order_payments has less rows than orders, then lastly it joins orders on order_payments.
 
## Our rule based optimizer is still fairly limited.  Can you think of a query in which it would perform a fairly catastrophic join order?
 
```sql
SELECT
    orders.order_id,
    order_payments.amount,
    order_details.quantity,
    products.name
 
FROM
  order_details
  JOIN order_payments ON order_details.order_id = order_payments.order_id
  JOIN orders ON orders.order_id = order_details.order_id OR order_payments.order_id = orders.order_id
  JOIN products ON order_details.product_id = products.product_id;
``` 

## Our rule based optimizer is still fairly limited.  If you were to improve it, what additional rules would you include?
 
Give join priority to tables without indexes, because the percent speedup will be greater for tables with indexes being joined later. 